### PR TITLE
Enable Helm in kustomize-build

### DIFF
--- a/hooks/kustomize-build
+++ b/hooks/kustomize-build
@@ -5,7 +5,7 @@ for i in $*
 do
     pushd `dirname $i`
     manifest=$(mktemp)
-    kustomize build . -o $manifest
+    kustomize build . --enable-helm -o $manifest
     # The intention was to run kubeval, but man it takes FOREVER on large yamls.  Disabling for now
     #kubeval --ignore-missing-schemas $manifest
     rm $manifest


### PR DESCRIPTION
Enabled Helm, so we can use the helm plugin during builds.